### PR TITLE
feat: store reqs and resps for predictions in sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # Игнорируем pyvenv.cfg
 pyvenv.cfg
+
+# Игнорируем *.db файлы
+*.db

--- a/main.py
+++ b/main.py
@@ -1,23 +1,54 @@
+from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from transformers import pipeline
 from pydantic import BaseModel
+from databases import Database
+import uuid
+# from local_db import db_init
+
+# Database connection
+database = Database("sqlite+aiosqlite:///requests.db")
 
 
 class Item(BaseModel):
     text: str
 
 
+class Request(BaseModel):
+    id: str
+    text: str
+    prediction: str
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Connect to database on start
+    # db_init()
+    await database.connect()
+    create_table_query = '''
+            CREATE TABLE IF NOT EXISTS requests
+            (id TEXT PRIMARY KEY,
+            text TEXT NOT NULL,
+            prediction TEXT NOT NULL)
+            '''
+    await database.execute(query=create_table_query)
+    query = "INSERT INTO requests(id, text, prediction) VALUES (:id, :text, :prediction)"
+    values = {"id": "test_id", "text": "test_text", "prediction": "test_prediction"}
+    await database.execute(query=query, values=values)
+    yield
+    # Disconnect from database on exit
+    await database.disconnect()
+
+app = FastAPI(lifespan=lifespan)
 classifier = pipeline("sentiment-analysis")
 
-
-
-@app.get("/")
-def root():
-    return {"message": "Hello World"}
-
-
 @app.post("/predict/")
-def predict(item: Item):
-    return classifier(item.text)[0]
+async def predict(item: Item):
+    request_id = str(uuid.uuid4())
+    prediction = classifier(item.text)[0]
+
+    query = "INSERT INTO requests(id, text, prediction) VALUES (:id, :text, :prediction)"
+    values = {"id": request_id, "text": item.text, "prediction": str(prediction)}
+    await database.execute(query=query, values=values)
+
+    return {"id": request_id, "prediction": prediction}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ uvicorn
 transformers
 torch
 httpx
+databases[aiosqlite]

--- a/test_main.py
+++ b/test_main.py
@@ -5,22 +5,25 @@ client = TestClient(app)
 
 
 def test_read_main():
-    response = client.get("/")
-    assert response.status_code == 200
-    assert response.json() == {"message": "Hello World"}
+    with TestClient(app) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.json() == {"message": "Hello World"}
 
 
 def test_predict_positive():
-    response = client.post("/predict/",
-                           json={"text": "I like machine learning!"})
-    json_data = response.json()
-    assert response.status_code == 200
-    assert json_data['label'] == 'POSITIVE'
+    with TestClient(app) as client:
+        response = client.post("/predict/",
+                               json={"text": "I like machine learning!"})
+        json_data = response.json()
+        assert response.status_code == 200
+        assert json_data['label'] == 'POSITIVE'
 
 
 def test_predict_negative():
-    response = client.post("/predict/",
-                           json={"text": "I hate machine learning!"})
-    json_data = response.json()
-    assert response.status_code == 200
-    assert json_data['label'] == 'NEGATIVE'
+    with TestClient(app) as client:
+        response = client.post("/predict/",
+                               json={"text": "I hate machine learning!"})
+        json_data = response.json()
+        assert response.status_code == 200
+        assert json_data['label'] == 'NEGATIVE'


### PR DESCRIPTION
add sqlite db storage of req's id, text and resp's label, score